### PR TITLE
Compensate for SweetAlert's poor handling of bound functions

### DIFF
--- a/lib/sweetalert.js
+++ b/lib/sweetalert.js
@@ -8,14 +8,6 @@ class SweetAlert extends React.Component {
 
   constructor(props) {
     super(props);
-
-    this.onConfirm = this.onConfirm.bind(this);
-  }
-
-  onConfirm(result) {
-    if (this.props.callback) {
-      this.props.callback(result);
-    }
   }
 
   render() {
@@ -23,7 +15,11 @@ class SweetAlert extends React.Component {
 
     if (isOpen) {
       let options = pick(this.props, Object.keys(SweetAlert.defaultProps));
-      swal(options, this.onConfirm);
+      swal(options, result => {
+        if (this.props.callback) {
+          this.props.callback(result);
+        }
+      });
     }
 
     return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React wrapper for SweetAlert",
   "main": "lib/sweetalert.js",
   "scripts": {


### PR DESCRIPTION
If you pass a bound function into SweetAlert it will never be called as a dismiss/cancel callback ([the buggy code](https://github.com/t4t5/sweetalert/blob/master/dev/modules/handle-click.js#L107-L108)). This is is a workaround.