### PR TITLE
Check that window exists before require

### DIFF
--- a/lib/sweetalert.js
+++ b/lib/sweetalert.js
@@ -2,7 +2,7 @@
 
 const isFunction = require('lodash.isfunction');
 const React = require('react');
-const swal = require('sweetalert');
+const swal = typeof window !== 'undefined' ? require('sweetalert') : null;
 const pick = require('lodash.pick');
 
 class SweetAlert extends React.Component {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "babel": "^5.8.3",
-    "babel-eslint": "^3.1.26",
+    "babel-eslint": "^4.1.6",
     "chance": "^0.7.6",
     "eslint": "^0.24.1",
     "eslint-plugin-nodeca": "^1.0.3",


### PR DESCRIPTION
This adds a check before requiring sweetalert. Sweetalert will throw a bunch of
errors if required in strict mode when the window isn't available.